### PR TITLE
Add dependent destroy to locations for soundtreks so that pins do not…

### DIFF
--- a/app/models/sound_trek.rb
+++ b/app/models/sound_trek.rb
@@ -1,5 +1,5 @@
 class SoundTrek < ApplicationRecord
   validates :location_id, :title, presence: true
   belongs_to :trekker, class_name: "User"
-  belongs_to :location
+  belongs_to :location, dependent: :destroy
 end


### PR DESCRIPTION
… show up on the map when a user deletes soundtrek