### PR TITLE
Hide create soundtrek button after it's clicked and when the form is …

### DIFF
--- a/app/assets/javascripts/map/map.js.erb
+++ b/app/assets/javascripts/map/map.js.erb
@@ -46,6 +46,7 @@ var options = {
 function getNewSoundTrekForm() {
   $('#create-sound-trek').on("click", function(event) {
     event.preventDefault();
+    $(this).hide();
     $.ajax({
       url: 'sound_treks/new',
       type: 'GET',


### PR DESCRIPTION
…appended, it is not added to the page but will show up again on page refresh